### PR TITLE
[GH-12258] lazy fields make entities to partial objects automatically

### DIFF
--- a/docs/en/reference/attributes-reference.rst
+++ b/docs/en/reference/attributes-reference.rst
@@ -190,6 +190,15 @@ Optional parameters:
    included when updating the row of the underlying entities table.
    If not specified, default value is true.
 
+-  **lazy** (requires PHP 8.4 with native lazy objects enabled): Boolean
+   value to mark the column as a lazy field. When ``true``, the column is
+   excluded from the initial ``SELECT`` when loading the entity, and its
+   value is fetched transparently on first access via a separate query.
+   This is useful for large columns (e.g. ``TEXT``, ``BLOB``) that are
+   rarely needed. Lazy fields must not be identifier fields, version
+   fields, or embedded fields. If not specified, default value is
+   ``false``. See :ref:`reference-lazy-fields`.
+
 -  **generated**: An enum with the possible values ALWAYS, INSERT, NEVER.  Is
    used after an INSERT or UPDATE statement to determine if the database
    generated this value and it needs to be fetched using a SELECT statement.

--- a/docs/en/reference/basic-mapping.rst
+++ b/docs/en/reference/basic-mapping.rst
@@ -167,6 +167,9 @@ Here is a complete list of ``Column``s attributes (all optional):
 - ``nullable`` (default: ``false``): Whether the column is nullable.
 - ``insertable`` (default: ``true``): Whether the column should be inserted.
 - ``updatable`` (default: ``true``): Whether the column should be updated.
+- ``lazy`` (default: ``false``, requires PHP 8.4 with native lazy objects enabled):
+  Whether the column should be deferred and loaded on first access.
+  See :ref:`reference-lazy-fields`.
 - ``generated`` (default: ``null``): Whether the generated strategy should be ``'NEVER'``, ``'INSERT'`` and ``ALWAYS``.
 - ``enumType`` (requires PHP 8.1 and ``doctrine/orm`` 2.11): The PHP enum class name to convert the database value into. See :ref:`reference-enum-mapping`.
 - ``precision`` (default: 0): The precision for a decimal (exact numeric) column

--- a/docs/en/reference/partial-objects.rst
+++ b/docs/en/reference/partial-objects.rst
@@ -144,3 +144,94 @@ eventually initialized:
     // to the database value — the in-memory change is preserved.
     echo $user->email;
     echo $user->name; // 'Bob'
+
+.. _reference-lazy-fields:
+
+Lazy Fields (PHP 8.4+)
+----------------------
+
+Instead of writing ``PARTIAL`` DQL queries manually, you can annotate individual
+columns in your mapping with ``lazy: true``. Doctrine will then automatically
+exclude those fields from every ``SELECT`` and load their values transparently
+on first access — without any changes to calling code.
+
+This is the recommended way to defer large columns (e.g. ``TEXT``, ``BLOB``)
+that are rarely needed, because it applies the optimization globally and
+uniformly, without requiring every query to be written as a ``PARTIAL`` query.
+
+.. note::
+
+    Lazy fields require PHP 8.4 with :ref:`native lazy objects enabled
+    <reference-native-lazy-objects>`.
+
+.. configuration-block::
+
+   .. code-block:: attribute
+
+        <?php
+        use Doctrine\ORM\Mapping as ORM;
+
+        #[ORM\Entity]
+        class BlogPost
+        {
+            #[ORM\Id, ORM\GeneratedValue, ORM\Column]
+            public int $id;
+
+            #[ORM\Column]
+            public string $title;
+
+            /** Large text body — deferred until actually needed. */
+            #[ORM\Column(lazy: true)]
+            public string $body;
+        }
+
+   .. code-block:: xml
+
+        <entity name="BlogPost" table="blog_post">
+            <id name="id" type="integer">
+                <generator strategy="AUTO"/>
+            </id>
+            <field name="title" type="string"/>
+            <field name="body" type="text" lazy="true"/>
+        </entity>
+
+On every ``find()``, ``findBy()``, ``findAll()``, or full-entity DQL query,
+the lazy column is excluded from the ``SELECT``:
+
+.. code-block:: php
+
+    <?php
+    $post = $em->find(BlogPost::class, 1);
+    // SQL: SELECT id, title FROM blog_post WHERE id = ?
+    // $post is a lazy ghost — $post->body is not yet fetched.
+
+    echo $post->title; // no query — title was already loaded
+
+    echo $post->body;
+    // SQL: SELECT id, title, body FROM blog_post WHERE id = ?
+    // Ghost is initialized; all fields now available.
+
+Constraints
+~~~~~~~~~~~
+
+- Lazy fields must not be identifier (``#[Id]``) fields.
+- Lazy fields must not be version (``#[Version]``) fields.
+- Lazy fields must not be embedded (``#[Embedded]``) fields.
+- The feature has no effect without PHP 8.4 and native lazy objects enabled
+  (the field is loaded eagerly as usual).
+
+Including a lazy field in DQL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``PARTIAL`` DQL query can explicitly include a lazy field, forcing it to
+be fetched in the same query:
+
+.. code-block:: php
+
+    <?php
+    $posts = $em->createQuery(
+        'SELECT PARTIAL p.{id, title, body} FROM App\Entity\BlogPost p'
+    )->getResult();
+
+    // body is now available without a further query.
+    echo $posts[0]->body;

--- a/doctrine-mapping.xsd
+++ b/doctrine-mapping.xsd
@@ -256,6 +256,7 @@
     <xs:attribute name="index" type="xs:boolean" default="false" />
     <xs:attribute name="insertable" type="xs:boolean" default="true" />
     <xs:attribute name="updatable" type="xs:boolean" default="true" />
+    <xs:attribute name="lazy" type="xs:boolean" default="false" />
     <xs:attribute name="generated" type="orm:generated-type" default="NEVER" />
     <xs:attribute name="enum-type" type="xs:string" />
     <xs:attribute name="version" type="xs:boolean" />

--- a/src/Mapping/Builder/FieldBuilder.php
+++ b/src/Mapping/Builder/FieldBuilder.php
@@ -129,6 +129,19 @@ class FieldBuilder
     }
 
     /**
+     * Marks the field as lazy-loaded (excluded from initial SELECT, loaded on first access).
+     * Requires PHP 8.4 native lazy objects to be enabled.
+     *
+     * @return $this
+     */
+    public function lazy(): static
+    {
+        $this->mapping['lazy'] = true;
+
+        return $this;
+    }
+
+    /**
      * Sets scale.
      *
      * @return $this

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -351,6 +351,15 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
     public array $fieldMappings = [];
 
     /**
+     * READ-ONLY: List of field names that are marked as lazy-loaded.
+     * Lazy fields are excluded from the initial SELECT and loaded on first access
+     * when PHP 8.4 native lazy objects are enabled.
+     *
+     * @var list<string>
+     */
+    public array $lazyFields = [];
+
+    /**
      * READ-ONLY: An array of field names. Used to look up field names from column names.
      * Keys are column names and values are field names.
      *
@@ -805,6 +814,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         if ($this->requiresFetchAfterChange) {
             $serialized[] = 'requiresFetchAfterChange';
+        }
+
+        if ($this->lazyFields !== []) {
+            $serialized[] = 'lazyFields';
         }
 
         return $serialized;
@@ -1275,6 +1288,20 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
                 && ! isset($mapping->options['values'])
             ) {
                 $mapping->options['values'] = array_column($mapping->enumType::cases(), 'value');
+            }
+        }
+
+        if ($mapping->lazy) {
+            if (! empty($mapping->id)) {
+                throw MappingException::lazyFieldMustNotBeIdentifier($this->name, $mapping->fieldName);
+            }
+
+            if ($mapping->fieldName === $this->versionField) {
+                throw MappingException::lazyFieldMustNotBeVersionField($this->name, $mapping->fieldName);
+            }
+
+            if ($mapping->declaredField !== null) {
+                throw MappingException::lazyFieldMustNotBeEmbedded($this->name, $mapping->fieldName);
             }
         }
 
@@ -1940,6 +1967,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
             $this->requiresFetchAfterChange = true;
         }
 
+        if ($mapping->lazy) {
+            $this->lazyFields[] = $mapping->fieldName;
+        }
+
         $this->fieldMappings[$mapping->fieldName] = $mapping;
     }
 
@@ -1975,6 +2006,10 @@ class ClassMetadata implements PersistenceClassMetadata, Stringable
 
         if (isset($fieldMapping->generated)) {
             $this->requiresFetchAfterChange = true;
+        }
+
+        if ($fieldMapping->lazy && ! in_array($fieldMapping->fieldName, $this->lazyFields, true)) {
+            $this->lazyFields[] = $fieldMapping->fieldName;
         }
     }
 

--- a/src/Mapping/Column.php
+++ b/src/Mapping/Column.php
@@ -32,6 +32,7 @@ final class Column implements MappingAttribute
         public readonly string|null $columnDefinition = null,
         public readonly string|null $generated = null,
         public readonly bool $index = false,
+        public readonly bool $lazy = false,
     ) {
     }
 }

--- a/src/Mapping/Driver/AttributeDriver.php
+++ b/src/Mapping/Driver/AttributeDriver.php
@@ -765,6 +765,10 @@ class AttributeDriver implements MappingDriver
             $mapping['enumType'] = $column->enumType;
         }
 
+        if ($column->lazy) {
+            $mapping['lazy'] = true;
+        }
+
         return $mapping;
     }
 }

--- a/src/Mapping/Driver/XmlDriver.php
+++ b/src/Mapping/Driver/XmlDriver.php
@@ -858,6 +858,10 @@ class XmlDriver extends FileDriver
             $mapping['enumType'] = (string) $fieldMapping['enum-type'];
         }
 
+        if (isset($fieldMapping['lazy']) && $this->evaluateBoolean($fieldMapping['lazy'])) {
+            $mapping['lazy'] = true;
+        }
+
         if (isset($fieldMapping->options)) {
             $mapping['options'] = $this->parseOptions($fieldMapping->options->children());
         }

--- a/src/Mapping/FieldMapping.php
+++ b/src/Mapping/FieldMapping.php
@@ -44,6 +44,8 @@ final class FieldMapping implements ArrayAccess
     public bool|null $unique = null;
     /** Whether an index should be generated for the column. */
     public bool|null $index = null;
+    /** Whether this field should be loaded lazily on first access (requires PHP 8.4 native lazy objects). */
+    public bool|null $lazy = null;
     /**
      * @var class-string|null This is set when the field is inherited by this
      * class from another (inheritance) parent <em>entity</em> class. The value
@@ -142,7 +144,7 @@ final class FieldMapping implements ArrayAccess
     {
         $serialized = ['type', 'fieldName', 'columnName'];
 
-        foreach (['nullable', 'notInsertable', 'notUpdatable', 'id', 'unique', 'version', 'quoted', 'index'] as $boolKey) {
+        foreach (['nullable', 'notInsertable', 'notUpdatable', 'id', 'unique', 'version', 'quoted', 'index', 'lazy'] as $boolKey) {
             if ($this->$boolKey) {
                 $serialized[] = $boolKey;
             }

--- a/src/Mapping/MappingException.php
+++ b/src/Mapping/MappingException.php
@@ -715,4 +715,31 @@ EXCEPTION
             $entityName,
         ));
     }
+
+    public static function lazyFieldMustNotBeIdentifier(string $entityName, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Field "%s#%s" is marked as lazy but is also an identifier. Identifier fields cannot be lazy.',
+            $entityName,
+            $fieldName,
+        ));
+    }
+
+    public static function lazyFieldMustNotBeVersionField(string $entityName, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Field "%s#%s" is marked as lazy but is also a version field. Version fields cannot be lazy.',
+            $entityName,
+            $fieldName,
+        ));
+    }
+
+    public static function lazyFieldMustNotBeEmbedded(string $entityName, string $fieldName): self
+    {
+        return new self(sprintf(
+            'Field "%s#%s" is marked as lazy but belongs to an embeddable. Embedded fields cannot be lazy.',
+            $entityName,
+            $fieldName,
+        ));
+    }
 }

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -733,7 +733,20 @@ class BasicEntityPersister implements EntityPersister
     ): object|null {
         $this->switchPersisterContext(null, $limit);
 
-        $sql              = $this->getSelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
+        // For the initial load ($entity === null) of a class with lazy fields, use the lazy
+        // SQL so those fields are excluded from the SELECT. The ghost initializer path passes
+        // $entity (the ghost itself), signalling that a full load is needed instead.
+        $useLazySql = $entity === null
+            && $this->class->lazyFields !== []
+            && $this->em->getConfiguration()->isNativeLazyObjectsEnabled();
+
+        if ($useLazySql) {
+            $hints['isPartial'] = true;
+            $sql                = $this->getLazySelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
+        } else {
+            $sql = $this->getSelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
+        }
+
         [$params, $types] = $this->expandParameters($criteria);
         $stmt             = $this->conn->executeQuery($sql, $params, $types);
 
@@ -879,16 +892,27 @@ class BasicEntityPersister implements EntityPersister
             static fn (Order $order): string => $order->value,
             $criteria->orderings(),
         );
-        $limit   = $criteria->getMaxResults();
-        $offset  = $criteria->getFirstResult();
-        $query   = $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
+        $limit  = $criteria->getMaxResults();
+        $offset = $criteria->getFirstResult();
+
+        $useLazySql = $this->class->lazyFields !== []
+            && $this->em->getConfiguration()->isNativeLazyObjectsEnabled();
+
+        $query = $useLazySql
+            ? $this->getLazySelectSQL($criteria, null, null, $limit, $offset, $orderBy)
+            : $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
 
         [$params, $types] = $this->expandCriteriaParameters($criteria);
 
         $stmt     = $this->conn->executeQuery($query, $params, $types);
         $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
+        $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
+        if ($useLazySql) {
+            $hints['isPartial'] = true;
+        }
+
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
     }
 
     /**
@@ -958,13 +982,24 @@ class BasicEntityPersister implements EntityPersister
     ): array {
         $this->switchPersisterContext($offset, $limit);
 
-        $sql              = $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
+        $useLazySql = $this->class->lazyFields !== []
+            && $this->em->getConfiguration()->isNativeLazyObjectsEnabled();
+
+        $sql = $useLazySql
+            ? $this->getLazySelectSQL($criteria, null, null, $limit, $offset, $orderBy)
+            : $this->getSelectSQL($criteria, null, null, $limit, $offset, $orderBy);
+
         [$params, $types] = $this->expandParameters($criteria);
         $stmt             = $this->conn->executeQuery($sql, $params, $types);
 
         $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, [UnitOfWork::HINT_DEFEREAGERLOAD => true]);
+        $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
+        if ($useLazySql) {
+            $hints['isPartial'] = true;
+        }
+
+        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
     }
 
     /**
@@ -1260,12 +1295,19 @@ class BasicEntityPersister implements EntityPersister
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList = [];
+        $columnList     = [];
+        $lazyColumnList = []; // column list with lazy fields excluded, for initial partial loads
         $this->currentPersisterContext->rsm->addEntityResult($this->class->name, 'r'); // r for root
 
         // Add regular columns to select list
         foreach ($this->class->fieldNames as $field) {
-            $columnList[] = $this->getSelectColumnSQL($field, $this->class);
+            $columnSQL      = $this->getSelectColumnSQL($field, $this->class);
+            $columnList[]   = $columnSQL;
+            // Lazy fields are present in the full column list but excluded from the lazy list.
+            // The shared RSM registers all fields; absent columns are simply ignored by the hydrator.
+            if (! ($this->class->fieldMappings[$field]->lazy ?? false)) {
+                $lazyColumnList[] = $columnSQL;
+            }
         }
 
         $this->currentPersisterContext->selectJoinSql = '';
@@ -1275,7 +1317,8 @@ class BasicEntityPersister implements EntityPersister
             $assocColumnSQL = $this->getSelectColumnAssociationSQL($assocField, $assoc, $this->class);
 
             if ($assocColumnSQL) {
-                $columnList[] = $assocColumnSQL;
+                $columnList[]     = $assocColumnSQL;
+                $lazyColumnList[] = $assocColumnSQL; // FK columns always present in both
             }
 
             $isAssocToOneInverseSide = $assoc->isToOne() && ! $assoc->isOwningSide();
@@ -1299,7 +1342,10 @@ class BasicEntityPersister implements EntityPersister
             $this->currentPersisterContext->rsm->addJoinedEntityResult($assoc->targetEntity, $assocAlias, 'r', $assocField);
 
             foreach ($eagerEntity->fieldNames as $field) {
-                $columnList[] = $this->getSelectColumnSQL($field, $eagerEntity, $assocAlias);
+                // Eager joined entity fields are always included in both lists
+                $eagerColumnSQL   = $this->getSelectColumnSQL($field, $eagerEntity, $assocAlias);
+                $columnList[]     = $eagerColumnSQL;
+                $lazyColumnList[] = $eagerColumnSQL;
             }
 
             foreach ($eagerEntity->associationMappings as $eagerAssocField => $eagerAssoc) {
@@ -1311,7 +1357,8 @@ class BasicEntityPersister implements EntityPersister
                 );
 
                 if ($eagerAssocColumnSQL) {
-                    $columnList[] = $eagerAssocColumnSQL;
+                    $columnList[]     = $eagerAssocColumnSQL;
+                    $lazyColumnList[] = $eagerAssocColumnSQL;
                 }
             }
 
@@ -1371,10 +1418,92 @@ class BasicEntityPersister implements EntityPersister
             $this->currentPersisterContext->selectJoinSql .= implode(' AND ', $joinCondition);
         }
 
-        $this->currentPersisterContext->selectColumnListSql = implode(', ', $columnList);
+        $this->currentPersisterContext->selectColumnListSql     = implode(', ', $columnList);
+        $this->currentPersisterContext->lazySelectColumnListSql = implode(', ', $lazyColumnList);
         $this->updateFilterHash();
 
         return $this->currentPersisterContext->selectColumnListSql;
+    }
+
+    /**
+     * Returns the SELECT column list with lazy fields excluded, for use in the initial load
+     * of entities that have lazy-mapped fields. The shared RSM registers all fields; the
+     * hydrator simply ignores columns absent from the query result.
+     */
+    protected function getLazySelectColumnsSQL(): string
+    {
+        if ($this->currentPersisterContext->lazySelectColumnListSql !== null && $this->isFilterHashUpToDate()) {
+            return $this->currentPersisterContext->lazySelectColumnListSql;
+        }
+
+        $this->getSelectColumnsSQL(); // populates both caches and selectJoinSql
+
+        return $this->currentPersisterContext->lazySelectColumnListSql;
+    }
+
+    /**
+     * Builds a SELECT SQL statement that excludes lazy fields, identical in structure to
+     * getSelectSQL() but using the lazy column list. Used for the initial entity load when
+     * the class has lazy-mapped fields and PHP 8.4 native lazy objects are enabled.
+     */
+    protected function getLazySelectSQL(
+        array|Criteria $criteria,
+        AssociationMapping|null $assoc = null,
+        LockMode|int|null $lockMode = null,
+        int|null $limit = null,
+        int|null $offset = null,
+        array|null $orderBy = null,
+    ): string {
+        $this->switchPersisterContext($offset, $limit);
+
+        $joinSql    = '';
+        $orderBySql = '';
+
+        if ($assoc !== null && $assoc->isManyToMany()) {
+            $joinSql = $this->getSelectManyToManyJoinSQL($assoc);
+        }
+
+        if ($assoc !== null && $assoc->isOrdered()) {
+            $orderBy = $assoc->orderBy();
+        }
+
+        if ($orderBy) {
+            $orderBySql = $this->getOrderBySQL($orderBy, $this->getSQLTableAlias($this->class->name));
+        }
+
+        $conditionSql = $criteria instanceof Criteria
+            ? $this->getSelectConditionCriteriaSQL($criteria)
+            : $this->getSelectConditionSQL($criteria, $assoc);
+
+        $lockSql = match ($lockMode) {
+            LockMode::PESSIMISTIC_READ => ' ' . $this->getReadLockSQL($this->platform),
+            LockMode::PESSIMISTIC_WRITE => ' ' . $this->getWriteLockSQL($this->platform),
+            default => '',
+        };
+
+        $columnList = $this->getLazySelectColumnsSQL();
+        $tableAlias = $this->getSQLTableAlias($this->class->name);
+        $filterSql  = $this->generateFilterConditionSQL($this->class, $tableAlias);
+        $tableName  = $this->quoteStrategy->getTableName($this->class, $this->platform);
+
+        if ($filterSql !== '') {
+            $conditionSql = $conditionSql
+                ? $conditionSql . ' AND ' . $filterSql
+                : $filterSql;
+        }
+
+        $select = 'SELECT ' . $columnList;
+        $from   = ' FROM ' . $tableName . ' ' . $tableAlias;
+        $join   = $this->currentPersisterContext->selectJoinSql . $joinSql;
+        $where  = ($conditionSql ? ' WHERE ' . $conditionSql : '');
+        $lock   = $this->platform->appendLockHint($from, $lockMode ?? LockMode::NONE);
+        $query  = $select
+            . $lock
+            . $join
+            . $where
+            . $orderBySql;
+
+        return $this->platform->modifyLimitQuery($query, $limit, $offset ?? 0) . $lockSql;
     }
 
     /** Gets the SQL join fragment used when selecting entities from an association. */

--- a/src/Persisters/Entity/BasicEntityPersister.php
+++ b/src/Persisters/Entity/BasicEntityPersister.php
@@ -741,8 +741,7 @@ class BasicEntityPersister implements EntityPersister
             && $this->em->getConfiguration()->isNativeLazyObjectsEnabled();
 
         if ($useLazySql) {
-            $hints['isPartial'] = true;
-            $sql                = $this->getLazySelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
+            $sql = $this->getLazySelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
         } else {
             $sql = $this->getSelectSQL($criteria, $assoc, $lockMode, $limit, null, $orderBy);
         }
@@ -755,8 +754,14 @@ class BasicEntityPersister implements EntityPersister
             $hints[Query::HINT_REFRESH_ENTITY] = $entity;
         }
 
+        $rsm = $this->currentPersisterContext->rsm;
+        if ($useLazySql) {
+            $rsm                      = clone $rsm;
+            $rsm->partialAliases['r'] = true;
+        }
+
         $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
-        $entities = $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
+        $entities = $hydrator->hydrateAll($stmt, $rsm, $hints);
 
         return $entities ? $entities[0] : null;
     }
@@ -908,11 +913,14 @@ class BasicEntityPersister implements EntityPersister
         $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
         $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
+
+        $rsm = $this->currentPersisterContext->rsm;
         if ($useLazySql) {
-            $hints['isPartial'] = true;
+            $rsm                      = clone $rsm;
+            $rsm->partialAliases['r'] = true;
         }
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
+        return $hydrator->hydrateAll($stmt, $rsm, $hints);
     }
 
     /**
@@ -995,11 +1003,14 @@ class BasicEntityPersister implements EntityPersister
         $hydrator = $this->em->newHydrator($this->currentPersisterContext->selectJoinSql ? Query::HYDRATE_OBJECT : Query::HYDRATE_SIMPLEOBJECT);
 
         $hints = [UnitOfWork::HINT_DEFEREAGERLOAD => true];
+
+        $rsm = $this->currentPersisterContext->rsm;
         if ($useLazySql) {
-            $hints['isPartial'] = true;
+            $rsm                      = clone $rsm;
+            $rsm->partialAliases['r'] = true;
         }
 
-        return $hydrator->hydrateAll($stmt, $this->currentPersisterContext->rsm, $hints);
+        return $hydrator->hydrateAll($stmt, $rsm, $hints);
     }
 
     /**

--- a/src/Persisters/Entity/CachedPersisterContext.php
+++ b/src/Persisters/Entity/CachedPersisterContext.php
@@ -25,6 +25,13 @@ class CachedPersisterContext
     public string|null $selectColumnListSql = null;
 
     /**
+     * The SELECT column list SQL fragment that excludes lazy fields.
+     * Used for the initial load of entities that have lazy-mapped fields.
+     * Populated alongside selectColumnListSql by getSelectColumnsSQL().
+     */
+    public string|null $lazySelectColumnListSql = null;
+
+    /**
      * The JOIN SQL fragment used to eagerly load all many-to-one and one-to-one
      * associations configured as FETCH_EAGER, as well as all inverse one-to-one associations.
      */

--- a/src/Persisters/Entity/JoinedSubclassPersister.php
+++ b/src/Persisters/Entity/JoinedSubclassPersister.php
@@ -370,6 +370,7 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
         }
 
         $columnList       = [];
+        $lazyColumnList   = []; // column list with lazy fields excluded
         $discrColumn      = $this->class->getDiscriminatorColumn();
         $discrColumnName  = $discrColumn->name;
         $discrColumnType  = $discrColumn->type;
@@ -386,7 +387,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 ? $this->em->getClassMetadata($mapping->inherited)
                 : $this->class;
 
-            $columnList[] = $this->getSelectColumnSQL($fieldName, $class);
+            $columnSQL    = $this->getSelectColumnSQL($fieldName, $class);
+            $columnList[] = $columnSQL;
+            if (! ($mapping->lazy ?? false)) {
+                $lazyColumnList[] = $columnSQL;
+            }
         }
 
         // Add foreign key columns
@@ -402,12 +407,14 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             $targetClass = $this->em->getClassMetadata($mapping->targetEntity);
 
             foreach ($mapping->joinColumns as $joinColumn) {
-                $columnList[] = $this->getSelectJoinColumnSQL(
+                $joinColumnSQL    = $this->getSelectJoinColumnSQL(
                     $tableAlias,
                     $joinColumn->name,
                     $this->quoteStrategy->getJoinColumnName($joinColumn, $this->class, $this->platform),
                     PersisterHelper::getTypeOfColumn($joinColumn->referencedColumnName, $targetClass, $this->em),
                 );
+                $columnList[]     = $joinColumnSQL;
+                $lazyColumnList[] = $joinColumnSQL; // FK columns always present in both
             }
         }
 
@@ -416,7 +423,9 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
             ? $baseTableAlias
             : $this->getSQLTableAlias($this->class->rootEntityName);
 
-        $columnList[] = $tableAlias . '.' . $discrColumnName;
+        $discrSql         = $tableAlias . '.' . $discrColumnName;
+        $columnList[]     = $discrSql;
+        $lazyColumnList[] = $discrSql; // discriminator always present
 
         // sub tables
         foreach ($this->class->subClasses as $subClassName) {
@@ -429,7 +438,11 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                     continue;
                 }
 
-                $columnList[] = $this->getSelectColumnSQL($fieldName, $subClass);
+                $columnSQL    = $this->getSelectColumnSQL($fieldName, $subClass);
+                $columnList[] = $columnSQL;
+                if (! ($mapping->lazy ?? false)) {
+                    $lazyColumnList[] = $columnSQL;
+                }
             }
 
             // Add join columns (foreign keys)
@@ -441,17 +454,20 @@ class JoinedSubclassPersister extends AbstractEntityInheritancePersister
                 $targetClass = $this->em->getClassMetadata($mapping->targetEntity);
 
                 foreach ($mapping->joinColumns as $joinColumn) {
-                    $columnList[] = $this->getSelectJoinColumnSQL(
+                    $joinColumnSQL    = $this->getSelectJoinColumnSQL(
                         $tableAlias,
                         $joinColumn->name,
                         $this->quoteStrategy->getJoinColumnName($joinColumn, $subClass, $this->platform),
                         PersisterHelper::getTypeOfColumn($joinColumn->referencedColumnName, $targetClass, $this->em),
                     );
+                    $columnList[]     = $joinColumnSQL;
+                    $lazyColumnList[] = $joinColumnSQL;
                 }
             }
         }
 
-        $this->currentPersisterContext->selectColumnListSql = implode(', ', $columnList);
+        $this->currentPersisterContext->selectColumnListSql     = implode(', ', $columnList);
+        $this->currentPersisterContext->lazySelectColumnListSql = implode(', ', $lazyColumnList);
         $this->updateFilterHash();
 
         return $this->currentPersisterContext->selectColumnListSql;

--- a/src/Persisters/Entity/SingleTablePersister.php
+++ b/src/Persisters/Entity/SingleTablePersister.php
@@ -34,12 +34,17 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
 
     protected function getSelectColumnsSQL(): string
     {
-        $columnList = [];
         if ($this->currentPersisterContext->selectColumnListSql !== null && $this->isFilterHashUpToDate()) {
             return $this->currentPersisterContext->selectColumnListSql;
         }
 
-        $columnList[] = parent::getSelectColumnsSQL();
+        // parent::getSelectColumnsSQL() populates both selectColumnListSql and lazySelectColumnListSql
+        // for the root entity fields. We build on top of those here.
+        $parentColumnList     = parent::getSelectColumnsSQL();
+        $parentLazyColumnList = $this->currentPersisterContext->lazySelectColumnListSql ?? $parentColumnList;
+
+        $columnList     = [$parentColumnList];
+        $lazyColumnList = [$parentLazyColumnList];
 
         $rootClass  = $this->em->getClassMetadata($this->class->rootEntityName);
         $tableAlias = $this->getSQLTableAlias($rootClass->name);
@@ -49,7 +54,9 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
         $discrColumnName = $discrColumn->name;
         $discrColumnType = $discrColumn->type;
 
-        $columnList[] = $tableAlias . '.' . $discrColumnName;
+        $discrSql         = $tableAlias . '.' . $discrColumnName;
+        $columnList[]     = $discrSql;
+        $lazyColumnList[] = $discrSql; // discriminator always present
 
         $resultColumnName = $this->getSQLResultCasing($this->platform, $discrColumnName);
 
@@ -66,7 +73,11 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
                     continue;
                 }
 
-                $columnList[] = $this->getSelectColumnSQL($fieldName, $subClass);
+                $columnSQL    = $this->getSelectColumnSQL($fieldName, $subClass);
+                $columnList[] = $columnSQL;
+                if (! ($mapping->lazy ?? false)) {
+                    $lazyColumnList[] = $columnSQL;
+                }
             }
 
             // Foreign key columns
@@ -78,17 +89,20 @@ class SingleTablePersister extends AbstractEntityInheritancePersister
                 $targetClass = $this->em->getClassMetadata($assoc->targetEntity);
 
                 foreach ($assoc->joinColumns as $joinColumn) {
-                    $columnList[] = $this->getSelectJoinColumnSQL(
+                    $joinColumnSQL    = $this->getSelectJoinColumnSQL(
                         $tableAlias,
                         $joinColumn->name,
                         $this->quoteStrategy->getJoinColumnName($joinColumn, $subClass, $this->platform),
                         PersisterHelper::getTypeOfColumn($joinColumn->referencedColumnName, $targetClass, $this->em),
                     );
+                    $columnList[]     = $joinColumnSQL;
+                    $lazyColumnList[] = $joinColumnSQL;
                 }
             }
         }
 
-        $this->currentPersisterContext->selectColumnListSql = implode(', ', $columnList);
+        $this->currentPersisterContext->selectColumnListSql     = implode(', ', $columnList);
+        $this->currentPersisterContext->lazySelectColumnListSql = implode(', ', $lazyColumnList);
         $this->updateFilterHash();
 
         return $this->currentPersisterContext->selectColumnListSql;

--- a/src/Query/SqlWalker.php
+++ b/src/Query/SqlWalker.php
@@ -1392,12 +1392,18 @@ class SqlWalker
     {
         $class = $this->getMetadataForDqlAlias($dqlAlias);
 
+        // Auto-skip lazy fields when native lazy objects are enabled and no explicit partial
+        // field set is provided. An explicit PARTIAL clause overrides lazy field behaviour
+        // because the user consciously listed every field they want.
+        $nativeLazyEnabled = $this->em->getConfiguration()->isNativeLazyObjectsEnabled();
+        $hasLazyFields     = $nativeLazyEnabled && $class->lazyFields !== [];
+
         if (! isset($this->selectedClasses[$dqlAlias])) {
             $this->selectedClasses[$dqlAlias] = [
                 'class'       => $class,
                 'dqlAlias'    => $dqlAlias,
                 'resultAlias' => $resultAlias,
-                'partial'     => $partialFieldSet !== [],
+                'partial'     => $partialFieldSet !== [] || $hasLazyFields,
             ];
         }
 
@@ -1406,6 +1412,11 @@ class SqlWalker
         // Select all fields from the queried class
         foreach ($class->fieldMappings as $fieldName => $mapping) {
             if ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true)) {
+                continue;
+            }
+
+            // Skip lazy fields unless they are explicitly listed in a PARTIAL clause
+            if (! $partialFieldSet && ($mapping->lazy ?? false) && $nativeLazyEnabled) {
                 continue;
             }
 
@@ -1446,6 +1457,10 @@ class SqlWalker
 
                 foreach ($subClass->fieldMappings as $fieldName => $mapping) {
                     if (isset($mapping->inherited) || ($partialFieldSet && ! in_array($fieldName, $partialFieldSet, true))) {
+                        continue;
+                    }
+
+                    if (! $partialFieldSet && ($mapping->lazy ?? false) && $nativeLazyEnabled) {
                         continue;
                     }
 

--- a/tests/Tests/Models/LazyField/LazyFieldPost.php
+++ b/tests/Tests/Models/LazyField/LazyFieldPost.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Models\LazyField;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\GeneratedValue;
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Table;
+
+#[Entity]
+#[Table(name: 'lazy_field_post')]
+class LazyFieldPost
+{
+    #[Id]
+    #[GeneratedValue]
+    #[Column]
+    public int $id;
+
+    #[Column]
+    public string $title;
+
+    #[Column(lazy: true)]
+    public string $body;
+}

--- a/tests/Tests/ORM/Functional/LazyFieldTest.php
+++ b/tests/Tests/ORM/Functional/LazyFieldTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\ORM\Functional;
+
+use Doctrine\ORM\Query;
+use Doctrine\Tests\Models\LazyField\LazyFieldPost;
+use Doctrine\Tests\OrmFunctionalTestCase;
+
+use function array_keys;
+use function str_contains;
+
+class LazyFieldTest extends OrmFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSchemaForModels(LazyFieldPost::class);
+    }
+
+    private function requireNativeLazy(): void
+    {
+        if (! $this->_em->getConfiguration()->isNativeLazyObjectsEnabled()) {
+            $this->markTestSkipped('Test requires PHP 8.4 native lazy objects to be enabled.');
+        }
+    }
+
+    private function createPost(string $title = 'Hello', string $body = 'World'): LazyFieldPost
+    {
+        $post        = new LazyFieldPost();
+        $post->title = $title;
+        $post->body  = $body;
+
+        $this->_em->persist($post);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        return $post;
+    }
+
+    public function testFindDoesNotSelectLazyField(): void
+    {
+        $this->requireNativeLazy();
+
+        $post = $this->createPost();
+        $this->getQueryLog()->reset()->enable();
+
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        self::assertNotNull($found);
+        self::assertQueryCount(1);
+        self::assertStringNotContainsString('body', $this->getQueryLog()->queries[0]['sql']);
+    }
+
+    public function testFindCreatesLazyGhost(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost();
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($found));
+    }
+
+    public function testEagerFieldAccessDoesNotTriggerInit(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('My Title', 'My Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+        $this->getQueryLog()->reset()->enable();
+
+        $title = $found->title;
+
+        self::assertSame('My Title', $title);
+        self::assertQueryCount(0, 'Accessing an eager field must not fire a query');
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($found));
+    }
+
+    public function testAccessingLazyFieldTriggersInitAndLoadsValue(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('My Title', 'My Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+        $this->getQueryLog()->reset()->enable();
+
+        $body = $found->body;
+
+        self::assertSame('My Body', $body);
+        self::assertQueryCount(1, 'Accessing a lazy field must fire exactly one SELECT');
+        self::assertFalse($this->_em->getUnitOfWork()->isUninitializedObject($found));
+    }
+
+    public function testLazyInitDoesNotOverwriteEagerFieldMutations(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('Original', 'The Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        // Mutate the eagerly-loaded field before lazy init fires.
+        $found->title = 'Modified';
+
+        // Access the lazy field — triggers full reload.
+        $body = $found->body;
+
+        self::assertSame('Modified', $found->title, 'In-memory mutation must survive lazy init');
+        self::assertSame('The Body', $body);
+    }
+
+    public function testFindByReturnsLazyGhosts(): void
+    {
+        $this->requireNativeLazy();
+
+        $this->createPost('A', 'Body A');
+        $this->getQueryLog()->reset()->enable();
+
+        $results = $this->_em->getRepository(LazyFieldPost::class)->findBy(['title' => 'A']);
+
+        self::assertCount(1, $results);
+        self::assertQueryCount(1);
+        self::assertStringNotContainsString('body', $this->getQueryLog()->queries[0]['sql']);
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($results[0]));
+    }
+
+    public function testFindAllReturnsLazyGhosts(): void
+    {
+        $this->requireNativeLazy();
+
+        $this->createPost('A', 'Body A');
+        $this->getQueryLog()->reset()->enable();
+
+        $results = $this->_em->getRepository(LazyFieldPost::class)->findAll();
+
+        self::assertNotEmpty($results);
+        self::assertQueryCount(1);
+        self::assertStringNotContainsString('body', $this->getQueryLog()->queries[0]['sql']);
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($results[0]));
+    }
+
+    public function testDqlFullSelectAutoSkipsLazyField(): void
+    {
+        $this->requireNativeLazy();
+
+        $post = $this->createPost('DQL Post', 'DQL Body');
+        $this->getQueryLog()->reset()->enable();
+
+        $dql     = 'SELECT p FROM ' . LazyFieldPost::class . ' p WHERE p.id = :id';
+        $results = $this->_em->createQuery($dql)
+            ->setParameter('id', $post->id)
+            ->getResult();
+
+        self::assertCount(1, $results);
+        self::assertQueryCount(1);
+        self::assertStringNotContainsString('body', $this->getQueryLog()->queries[0]['sql']);
+        self::assertTrue($this->_em->getUnitOfWork()->isUninitializedObject($results[0]));
+    }
+
+    public function testDqlPartialCanExplicitlyIncludeLazyField(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('DQL Post', 'Explicit Body');
+        $this->getQueryLog()->reset()->enable();
+
+        $dql     = 'SELECT PARTIAL p.{id, title, body} FROM ' . LazyFieldPost::class . ' p WHERE p.id = :id';
+        $results = $this->_em->createQuery($dql)
+            ->setParameter('id', $post->id)
+            ->getResult();
+
+        self::assertCount(1, $results);
+        self::assertQueryCount(1);
+        $sql = $this->getQueryLog()->queries[0]['sql'];
+        self::assertStringContainsString('body', $sql, 'PARTIAL with explicit body must include it in SELECT');
+    }
+
+    public function testPersistNewEntityWithLazyFieldWorks(): void
+    {
+        $post        = new LazyFieldPost();
+        $post->title = 'Persisted';
+        $post->body  = 'Persisted Body';
+
+        $this->_em->persist($post);
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+        self::assertNotNull($found);
+
+        // Force full load to check the persisted body
+        $body = $found->body;
+        self::assertSame('Persisted Body', $body);
+    }
+
+    public function testUpdateLazyFieldWorks(): void
+    {
+        $post  = $this->createPost('Update Test', 'Original Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        // Trigger init so we can modify body
+        $found->body = 'Updated Body';
+        $this->_em->flush();
+        $this->_em->clear();
+
+        $reloaded = $this->_em->find(LazyFieldPost::class, $post->id);
+        self::assertSame('Updated Body', $reloaded->body);
+    }
+
+    public function testRefreshLoadsLazyField(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('Refresh', 'Refresh Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        $this->getQueryLog()->reset()->enable();
+        $this->_em->refresh($found);
+
+        self::assertFalse($this->_em->getUnitOfWork()->isUninitializedObject($found));
+        // After refresh body is accessible without a further query
+        $body = $found->body;
+        self::assertSame('Refresh Body', $body);
+        // refresh fires 1 SELECT; body access must not fire another
+        self::assertQueryCount(1);
+    }
+
+    public function testOriginalEntityDataExcludesLazyFieldsAfterFind(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('OED Test', 'OED Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+
+        $oed = $this->_em->getUnitOfWork()->getOriginalEntityData($found);
+
+        self::assertArrayHasKey('title', $oed);
+        self::assertArrayNotHasKey('body', $oed, 'Lazy field must not appear in initial originalEntityData');
+    }
+
+    public function testOriginalEntityDataIncludesLazyFieldAfterInit(): void
+    {
+        $this->requireNativeLazy();
+
+        $post  = $this->createPost('OED Test', 'OED Body');
+        $found = $this->_em->find(LazyFieldPost::class, $post->id);
+        // Access lazy field to trigger init
+        $_ = $found->body;
+
+        $oed = $this->_em->getUnitOfWork()->getOriginalEntityData($found);
+
+        self::assertArrayHasKey('body', $oed);
+        self::assertSame('OED Body', $oed['body']);
+    }
+}


### PR DESCRIPTION
Related:
* https://github.com/doctrine/orm/issues/12258

I haven't reviewed this code yet, its based on a refined plan and planning session with Claude.

```php
        #[ORM\Entity]
        class BlogPost
        {
            #[ORM\Id, ORM\GeneratedValue, ORM\Column]
            public int $id;

            #[ORM\Column]
            public string $title;

            /** Large text body — deferred until actually needed. */
            #[ORM\Column(lazy: true)]
            public string $body;
        }
```

Some decisions by Claude to review later:

>  Root causes fixed in this session:
>
 > 1. QueryLog.reset() disables logging — Fixed by chaining ->enable() after ->reset() in all LazyFieldTest methods that reset the log before asserting query counts.
 > 2. isPartial hint overwritten by hydrators — SimpleObjectHydrator::prepare() always sets $this->hints['isPartial'] = count($this->rsm->partialAliases) > 0, ignoring any hint
  passed by the caller. Fixed by cloning the RSM in BasicEntityPersister::load(), loadCriteria(), and loadAll() when > using lazy SQL, then setting $rsm->partialAliases['r'] =
  true on the clone — the hydrator then picks up the partial flag correctly from the RSM itself.
```
